### PR TITLE
Fixes RuntimeException: Cannot override frozen service issue

### DIFF
--- a/simplesearch.php
+++ b/simplesearch.php
@@ -102,6 +102,10 @@ class SimplesearchPlugin extends Plugin
             $page->template($template_override);
         }
 
+        // allows us to redefine the page service without triggering RuntimeException: Cannot override frozen service
+        // "page" issue
+        unset($this->grav['page']);
+        
         $this->grav['page'] = $page;
     }
 


### PR DESCRIPTION
This fixes the RuntimeException from Pimple. Only thing is I don't know if this is will have other repercussions. I tried it in both the bare example and the blog skeleton example. Both worked. 
