### PR TITLE
Added a check for the query URI parameter

### DIFF
--- a/simplesearch.php
+++ b/simplesearch.php
@@ -39,7 +39,7 @@ class SimplesearchPlugin extends Plugin
     {
         /** @var Uri $uri */
         $uri = $this->grav['uri'];
-        $query = $uri->param('query');
+        $query = $uri->param('query') ?: $uri->query('query');
         $route = $this->config->get('plugins.simplesearch.route');
 
         if ($route && $route == $uri->path() && $query) {


### PR DESCRIPTION
With this addition, creating a simple HTML search form is possible.

``` html
<form action="{{ base_url_relative }}/search" method="get">
    <input type="text" name="query" />
    <button>Search</button>
 </form>
```

Personally I think a 'query' URI parameter should take precedence over a path segment, but I'm not deep enough into Grav to make that call. So my preference would look like:

``` php
$uri->query('query') ?: $uri->param('query');
```

As long as the user isn't doing something like `/search/query:ipsum?query=lorem` everything should be fine.
