### PR TITLE
Update the note on empty filters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ order:
 
 By creating the configuration file: `user/config/plugins/simplesearch.yaml` you have effectively created a site-wide configuration for SimpleSearch.  However, you may want to have multiple searches.  
 
-> NOTE: If you remove the `filters:` section SimpleSearch will search **ALL PAGES**
+> NOTE: If you want to search **ALL PAGES** just keep the `filters: []` section empty.
 
 To accomplish multiple search types in a single site, you should use **page-based** configuration. This is simple to do, simply provide any or all of the configuration options under a `simplesearch:` header in your page frontmatter.  For example:
 


### PR DESCRIPTION
The problem is, if you delete your filter section in the user/config/plugins/simplesearch.yaml then the one from the plugin itself kicks in and takes over and filters by blog, but that's not what people want by default I think.