### PR TITLE
Update simplesearch_results.html.twig

### DIFF
--- a/templates/simplesearch_results.html.twig
+++ b/templates/simplesearch_results.html.twig
@@ -2,14 +2,14 @@
 
 {% block content %}
     <div class="content-padding simplesearch">
-    <h1 class="search-header">Search Results</h1>
+    <h1 class="search-header">Rezultatele căutării:</h1>
     <div class="center">
         {% include 'partials/simplesearch_searchbox.html.twig' %}
 
     </div>
 
 
-    <p>Query: <strong>{{ query }}</strong> found {{ search_results.count }} {{ 'result'|pluralize(search_results.count) }}</p>
+    <p>Căutarea: <strong>{{ query }}</strong> a găsit {{ search_results.count }} {{ 'rezultate' }}</p>
     {% for page in search_results %}
         {% include 'partials/simplesearch_item.html.twig' with {'page':page} %}
     {% endfor %}


### PR DESCRIPTION
update with Romanian translation - no need to pluralize the results counts as it is correct with `rezultate`