### PR TITLE
Fix searching on @self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 1. [](#new)
     * Multiple search boxes support [#52](https://github.com/getgrav/grav-plugin-simplesearch/pull/52)
+1. [](#bugfix)
+    * Fix searching on `@self   `[#53](https://github.com/getgrav/grav-plugin-simplesearch/pull/53)
 
 # v1.8.0
 ## 07/14/2016


### PR DESCRIPTION
Refs #51 

If a page had

```
simplesearch:
route: '@self'
```

then search was not really working