### PR TITLE
Removed jQuery dependency

### DIFF
--- a/templates/partials/simplesearch_searchbox.html.twig
+++ b/templates/partials/simplesearch_searchbox.html.twig
@@ -1,22 +1,31 @@
 <div class="search-wrapper">
-    <input class="search-input" type="text" placeholder="{{"PLUGIN_SIMPLESEARCH.SEARCH_PLACEHOLDER"|t}}" value="{{ query }}" data-search-input="{{ base_url }}{{ config.plugins.simplesearch.route}}/query" />
+    <input id="searchfield" class="search-input" type="text" placeholder="{{"PLUGIN_SIMPLESEARCH.SEARCH_PLACEHOLDER"|t}}" value="{{ query }}" data-search-input="{{ base_url }}{{ config.plugins.simplesearch.route}}/query" />
     {% if config.plugins.simplesearch.display_button %}
         <button class="search-submit"><img src="{{ url('plugin://simplesearch/assets/search.svg') }}" /></button>
     {% endif %}
     <script>
-    jQuery(document).ready(function($){
-        $('.search-input').on('keypress', function(event) {
-            var input = $(event.currentTarget);
-            if (event.which == 13 && input.val().length >= {{ config.get('plugins.simplesearch.min_query_length', 3) }}) {
+
+        var input = document.getElementsByClassName('search-input');
+        var searchInput = input[0].dataset.searchInput;
+
+        for(var i=0; i<input.length; i++) {
+            var el = input[i];
+            el.addEventListener('keypress', function(event){
+                if (event.keyCode == 13 && el.value.length >= {{ config.get('plugins.simplesearch.min_query_length', 3) }}) {
+                    event.preventDefault();
+                    window.location.href = searchInput + '{{ config.system.param_sep }}' + el.value;
+                }
+            }, false);
+        }
+
+        var button = document.getElementsByClassName('search-submit');
+        for(var i=0; i<input.length; i++) {
+            var el = button[i];
+            el.addEventListener('click', function(event){
                 event.preventDefault();
-                window.location.href = input.data('search-input') + '{{ config.system.param_sep }}' + input.val();
-            }
-        });
-        $('.search-submit').on('click', function(event) {
-            var input = $(event.currentTarget).prev('.search-input');
-            event.preventDefault();
-            window.location.href = input.data('search-input') + '{{ config.system.param_sep }}' + input.val();
-        });
-    });
+                window.location.href = searchInput + '{{ config.system.param_sep }}' + input[0].value;
+            });
+        }
+
     </script>
 </div>

--- a/templates/partials/simplesearch_searchbox.html.twig
+++ b/templates/partials/simplesearch_searchbox.html.twig
@@ -19,6 +19,7 @@
             }, false);
         }
 
+        {% if config.plugins.simplesearch.display_button %}
         var button = document.getElementsByClassName('search-submit');
         for(i=0; i<input.length; i++) {
             el = button[i];
@@ -27,6 +28,7 @@
                 window.location.href = searchInput + '{{ config.system.param_sep }}' + input[0].value;
             });
         }
+        {% endif %}
 
     </script>
 </div>

--- a/templates/partials/simplesearch_searchbox.html.twig
+++ b/templates/partials/simplesearch_searchbox.html.twig
@@ -1,26 +1,27 @@
 <div class="search-wrapper">
-    <input id="searchfield" class="search-input" type="text" placeholder="{{"PLUGIN_SIMPLESEARCH.SEARCH_PLACEHOLDER"|t}}" value="{{ query }}" data-search-input="{{ base_url }}{{ config.plugins.simplesearch.route}}/query" />
+    <input class="search-input" type="text" placeholder="{{"PLUGIN_SIMPLESEARCH.SEARCH_PLACEHOLDER"|t}}" value="{{ query }}" data-search-input="{{ base_url }}{{ config.plugins.simplesearch.route}}/query" />
     {% if config.plugins.simplesearch.display_button %}
         <button class="search-submit"><img src="{{ url('plugin://simplesearch/assets/search.svg') }}" /></button>
     {% endif %}
     <script>
 
+        var i, el;
         var input = document.getElementsByClassName('search-input');
         var searchInput = input[0].dataset.searchInput;
 
-        for(var i=0; i<input.length; i++) {
-            var el = input[i];
+        for(i=0; i<input.length; i++) {
+            el = input[i];
             el.addEventListener('keypress', function(event){
-                if (event.keyCode == 13 && el.value.length >= {{ config.get('plugins.simplesearch.min_query_length', 3) }}) {
+                if (event.keyCode == 13 && this.value.length >= {{ config.get('plugins.simplesearch.min_query_length', 3) }}) {
                     event.preventDefault();
-                    window.location.href = searchInput + '{{ config.system.param_sep }}' + el.value;
+                    window.location.href = searchInput + '{{ config.system.param_sep }}' + this.value;
                 }
             }, false);
         }
 
         var button = document.getElementsByClassName('search-submit');
-        for(var i=0; i<input.length; i++) {
-            var el = button[i];
+        for(i=0; i<input.length; i++) {
+            el = button[i];
             el.addEventListener('click', function(event){
                 event.preventDefault();
                 window.location.href = searchInput + '{{ config.system.param_sep }}' + input[0].value;


### PR DESCRIPTION
With jQuery required so explicitly, this pretty much forces the user to have assets at the top of the file, else jQuery will be undefined. By removing the dependency on jQuery, this is still cross-browser compatible but now allows for JS assets to be output anywhere else in the page.
