### PR TITLE
Published e Routable filter

### DIFF
--- a/simplesearch.php
+++ b/simplesearch.php
@@ -158,7 +158,19 @@ class SimplesearchPlugin extends Plugin
             }
         }
 
-
+        $filter_published = $this->config->get('plugins.simplesearch.published', null);
+        if ($filter_published === true) {
+           $this->collection->published();
+        } elseif ($filter_published === false) {
+           $this->collection->nonPublished();
+        }
+        $filter_routable = $this->config->get('plugins.simplesearch.routable', null);
+        if ($filter_routable === true) {
+           $this->collection->routable();
+        } elseif ($filter_routable === false) {
+           $this->collection->nonRoutable();
+        }
+        
         $extras = [];
 
         if ($query) {


### PR DESCRIPTION
I propose to add two filter in config file: published and routable. In default yaml file they are initializated to "true". Before this changes the plugin shows pages marked  "published: false" and "routable: false" too! The  “routable: false” pages search result is a link that won't work!