### PR TITLE
Published e Routable filter

### DIFF
--- a/simplesearch.yaml
+++ b/simplesearch.yaml
@@ -10,3 +10,5 @@ filter_combinator: and
 order:
     by: date
     dir: desc
+published: true
+routable: true


### PR DESCRIPTION
I propose to add two filter in config file: published and routable. In default yaml they are initializated to "true". Before this changes the plugin shows shows pages market "published: false" and "routable: false" too! The  “routable: false” pages search result is a link that won't work!