### PR TITLE
Added support for accented characters

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -48,7 +48,7 @@ form:
       validate:
         type: bool
 
-ignore_accented_characters:
+    ignore_accented_characters:
       type: toggle
       label: Ignote accented characters
       help: If enabled, search terms will match accented characters regardless to their diacritics i.e. search results will show up for "cafe" and "café" no matter how you typed it.
@@ -60,7 +60,7 @@ ignore_accented_characters:
       validate:
         type: bool
 
-min_query_length:
+    min_query_length:
       type: text
       size: x-small
       label: Minimum query length

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -48,7 +48,19 @@ form:
       validate:
         type: bool
 
-    min_query_length:
+ignore_accented_characters:
+      type: toggle
+      label: Ignote accented characters
+      help: If enabled, search terms will match accented characters regardless to their diacritics i.e. search results will show up for "cafe" and "café" no matter how you typed it.
+      highlight: 0
+      default: 0
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
+
+min_query_length:
       type: text
       size: x-small
       label: Minimum query length

--- a/simplesearch.php
+++ b/simplesearch.php
@@ -230,15 +230,24 @@ class SimplesearchPlugin extends Plugin
         }
     }
 
+    private function matchText($haystack, $needle) {
+        if ($this->config->get('plugins.simplesearch.ignore_accented_characters')) {
+            setlocale(LC_ALL, 'en_US');
+            $result = mb_stripos(iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $haystack), iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $needle));
+            setlocale(LC_ALL, '');
+            return $result;
+        } else {
+            return mb_stripos($haystack, $needle);
+        }
+    }
+
     private function notFound($query, $page, $taxonomies)
     {
-        setlocale(LC_ALL, 'en_US');
-        $query = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $query);
         $searchable_types = ['title', 'content', 'taxonomy'];
         $results = true;
         foreach ($searchable_types as $type) {
             if ($type === 'title') {
-                $result = mb_stripos(iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', strip_tags($page->title())), $query) === false;
+                $result = $this->matchText(strip_tags($page->title()), $query) === false;
             } elseif ($type === 'taxonomy') {
                 if ($taxonomies === false) {
                     continue;
@@ -252,21 +261,20 @@ class SimplesearchPlugin extends Plugin
                     }
 
                     $taxonomy_values = implode('|',$values);
-                    if (mb_stripos(iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $taxonomy_values), $query) !== false) {
+                    if ($this->matchText($taxonomy_values, $query) !== false) {
                         $taxonomy_match = true;
                         break;
                     }
                 }
                 $result = !$taxonomy_match;
             } else {
-                $result = mb_stripos(iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', strip_tags($page->content())), $query) === false;
+                $result = $this->matchText(strip_tags($page->content()), $query) === false;
             }
             $results = $results && $result;
             if ($results === false ) {
                 break;
             }
         }
-        setlocale(LC_ALL, '');
         return $results;
     }
 }

--- a/simplesearch.php
+++ b/simplesearch.php
@@ -232,11 +232,13 @@ class SimplesearchPlugin extends Plugin
 
     private function notFound($query, $page, $taxonomies)
     {
+        setlocale(LC_ALL, 'en_US');
+        $query = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $query);
         $searchable_types = ['title', 'content', 'taxonomy'];
         $results = true;
         foreach ($searchable_types as $type) {
             if ($type === 'title') {
-                $result = mb_stripos(strip_tags($page->title()), $query) === false;
+                $result = mb_stripos(iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', strip_tags($page->title())), $query) === false;
             } elseif ($type === 'taxonomy') {
                 if ($taxonomies === false) {
                     continue;
@@ -250,20 +252,21 @@ class SimplesearchPlugin extends Plugin
                     }
 
                     $taxonomy_values = implode('|',$values);
-                    if (mb_stripos($taxonomy_values, $query) !== false) {
+                    if (mb_stripos(iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $taxonomy_values), $query) !== false) {
                         $taxonomy_match = true;
                         break;
                     }
                 }
                 $result = !$taxonomy_match;
             } else {
-                $result = mb_stripos(strip_tags($page->content()), $query) === false;
+                $result = mb_stripos(iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', strip_tags($page->content())), $query) === false;
             }
             $results = $results && $result;
             if ($results === false ) {
                 break;
             }
         }
+        setlocale(LC_ALL, '');
         return $results;
     }
 }

--- a/simplesearch.yaml
+++ b/simplesearch.yaml
@@ -7,6 +7,7 @@ template: simplesearch_results
 filters:
     category: blog
 filter_combinator: and
+ignore_accented_characters: true
 order:
     by: date
     dir: desc


### PR DESCRIPTION
I added an iconv conversion to every matched string so that accented characters are transliterated to their unaccented versions before searching. This is simple multilanguage support and this is how Google works, for example. For example if you search for "perez" it will return results containing "pérez" too.

I don't think it is necessary for this to be a configurable option because I can't really think of a situation where this would not come in handy. 