### PR TITLE
Added check for ACL in Header of pages when searching

### DIFF
--- a/simplesearch.php
+++ b/simplesearch.php
@@ -166,6 +166,9 @@ class SimplesearchPlugin extends Plugin
         //Drop unpublished and unroutable pages
         $this->collection->published()->routable();
 
+        //Check if user has permission to view page
+        $this->collection = $this->checkForPermissions($this->collection);
+
         $extras = [];
 
         if ($query) {
@@ -219,6 +222,55 @@ class SimplesearchPlugin extends Plugin
         }
     }
 
+    /**
+     * Filter the pages, and return only the pages the user has access to.
+     * Implementation based on Login Plugin authorizePage() function.
+     */
+    public function checkForPermissions($collection)
+    {
+        $user = $this->grav['user'];
+        $returnCollection = new Collection();
+        foreach ($collection as $page) {
+
+            $header = $page->header();
+            $rules = isset($header->access) ? (array)$header->access : [];
+
+            if ($this->config->get('plugins.login.parent_acl')) {
+                // If page has no ACL rules, use its parent's rules
+                if (!$rules) {
+                    $parent = $page->parent();
+                    while (!$rules and $parent) {
+                        $header = $parent->header();
+                        $rules = isset($header->access) ? (array)$header->access : [];
+                        $parent = $parent->parent();
+                    }
+                }
+            }
+
+            // Continue to the page if it has no ACL rules.
+            if (!$rules) {
+                $returnCollection[$page->path()] = ['slug' => $page->slug()];
+            } else {
+                // Continue to the page if user is authorized to access the page.
+                foreach ($rules as $rule => $value) {
+                    if (is_array($value)) {
+                        foreach ($value as $nested_rule => $nested_value) {
+                            if ($user->authorize($rule . '.' . $nested_rule) == $nested_value) {
+                                $returnCollection[$page->path()] = ['slug' => $page->slug()];
+                                break;
+                            }
+                        }
+                    } else {
+                        if ($user->authorize($rule) == $value) {
+                            $returnCollection[$page->path()] = ['slug' => $page->slug()];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return $returnCollection;
+    }
 
     /**
      * Set needed variables to display the search results.


### PR DESCRIPTION
The SimpleSearch Plugin returns results for pages that are protected by ACL Rules like
```
access:
    site.login: true
```
It is not enough to filter the results in the twig template for search results, since there is also an json formatted endpoint (/search.json/query:Example).