### PR TITLE
Fix order of sprintf variables in french translation

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -23,7 +23,7 @@ fr:
         SEARCH_PLACEHOLDER: "Recherche..."
         SEARCH_RESULTS: "Résultats de la recherche"
         SEARCH_RESULTS_SUMMARY_SINGULAR: "Recherche : Un résultat trouvé pour <strong>%s</strong>"
-        SEARCH_RESULTS_SUMMARY_PLURAL: "Recherche : %s résultats trouvés pour <strong>%s</strong>"
+        SEARCH_RESULTS_SUMMARY_PLURAL: "Recherche : %2$s résultats trouvés pour <strong>%1$s</strong>"
 
 it:
     PLUGIN_SIMPLESEARCH:


### PR DESCRIPTION
Use case: "vendée" is the searched term, "2" is the number of results.

Without the fix:

> Recherche : vendée résultats trouvés pour 2

(litterally: "there is vendée results for the search of '2'")

With it:

> Recherche : 2 résultats trouvés pour vendée

Maybe other languages need this fix too.