### PR TITLE
Update simplesearch.yaml

### DIFF
--- a/simplesearch.yaml
+++ b/simplesearch.yaml
@@ -6,7 +6,8 @@ route: /search
 search_content: rendered
 template: simplesearch_results
 filters:
-    category: blog
+  category:
+    - '@none'
 filter_combinator: and
 ignore_accented_characters: false
 order:


### PR DESCRIPTION
It seems to make more sense to have the default be @none so users can search the entire site (at least users can see the search working right out of the box).