### PR TITLE
Add option to disable built-in JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,18 @@ You should now have all the plugin files under
 To effectively use the plugin, you first need to create an override config. To do so, create the folder `user/config/plugins` (if it doesn't exist already) and copy the [simplesearch.yaml][simplesearch] config file in there.
 
 ```
-search_content: rendered
 enabled: true
 built_in_css: true
+built_in_js: true
 display_button: false
 min_query_length: 3
 route: /search
+search_content: rendered
 template: simplesearch_results
 filters:
     category: blog
 filter_combinator: and
+ignore_accented_characters: false
 order:
     by: date
     dir: desc

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -47,6 +47,17 @@ form:
       validate:
         type: bool
 
+    built_in_js:
+      type: toggle
+      label: Use built in javascript
+      highlight: 1
+      default: 1
+      options:
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
+      validate:
+        type: bool
+
     display_button:
       type: toggle
       label: Display Search Button

--- a/simplesearch.php
+++ b/simplesearch.php
@@ -296,8 +296,9 @@ class SimplesearchPlugin extends Plugin
             $this->grav['assets']->add('plugin://simplesearch/css/simplesearch.css');
         }
 
-
-        $this->grav['assets']->addJs('plugin://simplesearch/js/simplesearch.js', [ 'group' => 'bottom' ]);
+        if ($this->config->get('plugins.simplesearch.built_in_js')) {
+            $this->grav['assets']->addJs('plugin://simplesearch/js/simplesearch.js', [ 'group' => 'bottom' ]);
+        }
     }
 
     private function matchText($haystack, $needle) {

--- a/simplesearch.yaml
+++ b/simplesearch.yaml
@@ -1,5 +1,6 @@
 enabled: true
 built_in_css: true
+built_in_js: true
 display_button: false
 min_query_length: 3
 route: /search


### PR DESCRIPTION
Added option to disable the `js/simplesearch.js` built-in javascript. 
Just like we can do with built-in CSS.
Useful when someone wanna use custom JS or another search twig templates.
Well, at least, I need it. So there is the patch ;)