### PR TITLE
Issue #131 ensure $values is an array to prevent PHP error on implode()

### DIFF
--- a/simplesearch.php
+++ b/simplesearch.php
@@ -339,7 +339,7 @@ class SimplesearchPlugin extends Plugin
                 $taxonomy_match = false;
                 foreach ((array) $page_taxonomies as $taxonomy => $values) {
                     // if taxonomies filter set, make sure taxonomy filter is valid
-                    if (is_array($taxonomies) && !empty($taxonomies) && !in_array($taxonomy, $taxonomies)) {
+                    if (!is_array($values) || (is_array($taxonomies) && !empty($taxonomies) && !in_array($taxonomy, $taxonomies))) {
                         continue;
                     }
 


### PR DESCRIPTION
Some plugins (such as Events) add taxonomy values that do not resolve in arrays as the simplesearch expects, so skip them.