### PR TITLE
Search form field passed variable name fix.

### DIFF
--- a/templates/partials/simplesearch_searchbox.html.twig
+++ b/templates/partials/simplesearch_searchbox.html.twig
@@ -2,7 +2,7 @@
 <div class="search-wrapper">
     <form name="search" data-simplesearch-form>
         <input
-            name="searchfield"
+            name="query"
             class="search-input"
             type="text"
             {% if min_chars > 0 %} min="{{- min_chars -}}" {% endif %}


### PR DESCRIPTION
The `name` of a form field's input is also the variable-name that is passed. Apparently the search plugin expects a variable named: "query" to be passed, not a "searchfield"-named variable. Performing a manual search from the dedicated page does not present any results without this change.