### PR TITLE
input attribute fix

### DIFF
--- a/js/simplesearch.js
+++ b/js/simplesearch.js
@@ -10,7 +10,7 @@
     var fields = document.querySelectorAll('input[name="searchfield"][data-search-input]');
     Array.prototype.forEach.call(fields, function(field) {
         var form = findAncestor(field, 'form[data-simplesearch-form]'),
-            min = field.getAttribute('min') || false,
+            min = field.getAttribute('data-min') || false,
             location = field.getAttribute('data-search-input'),
             separator = field.getAttribute('data-search-separator');
 

--- a/templates/partials/simplesearch_searchbox.html.twig
+++ b/templates/partials/simplesearch_searchbox.html.twig
@@ -5,7 +5,7 @@
             name="searchfield"
             class="search-input"
             type="text"
-            {% if min_chars > 0 %} min="{{- min_chars -}}" {% endif %}
+            {% if min_chars > 0 %} data-min="{{- min_chars -}}" {% endif %}
             required
             placeholder="{{"PLUGIN_SIMPLESEARCH.SEARCH_PLACEHOLDER"|t}}"
             value="{{ query|e }}"


### PR DESCRIPTION
HTML5 validation error: attribute min not allowed on element input at this point. 
Attribute min uses when type is date, month, week, time, datetime-local, number, or range.