### PR TITLE
Prevent the default filter being blog

### DIFF
--- a/simplesearch.yaml
+++ b/simplesearch.yaml
@@ -7,7 +7,7 @@ route: /search
 search_content: rendered
 template: simplesearch_results
 filters:
-    category: blog
+    category:
 filter_combinator: and
 ignore_accented_characters: false
 order:


### PR DESCRIPTION
When the category is removed when using the admin plugin, the user config falls back to using the default configuration for `filters`, which will be just an empty array when parsed. This will fix #158 and provide better default behavior.