### PR TITLE
search the content of modular pages

### DIFF
--- a/simplesearch.php
+++ b/simplesearch.php
@@ -171,8 +171,21 @@ class SimplesearchPlugin extends Plugin
             }
         }
 
-        //Drop unpublished and unroutable pages
-        $this->collection->published()->routable();
+        //Drop unpublished pages, but do not drop unroutable pages right now to be able to search modular pages which are unroutable per se
+        $this->collection->published();
+        /** @var modular Pages $modularPageCollection */
+        $modularPageCollection = $this->collection->copy();
+        //Get published modular pages
+        $modularPageCollection->modular();
+        foreach ($modularPageCollection as $cpage) {
+            if (!$cpage->parent()->published()) {
+                $modularPageCollection->remove($cpage);
+            }
+        }
+        //Drop unroutable pages
+        $this->collection->routable();
+        //Add modular pages again
+        $this->collection->merge($modularPageCollection);
 
         //Check if user has permission to view page
         if ($this->grav['config']->get('plugins.login.enabled')) {


### PR DESCRIPTION
As already discovered by  mikegcox see [his comment at issue 93](https://github.com/getgrav/grav-plugin-simplesearch/issues/93#issuecomment-302089444) modular pages are not considered at all during searching. Thus do not remove published modular pages from the collection to be searched.