### PR TITLE
Extract searchable_types to config, allowing limit search scope

### DIFF
--- a/simplesearch.php
+++ b/simplesearch.php
@@ -302,7 +302,7 @@ class SimplesearchPlugin extends Plugin
      */
     private function notFound($query, $page, $taxonomies)
     {
-        $searchable_types = ['title', 'content', 'taxonomy'];
+        $searchable_types = $search_content = $this->config->get('plugins.simplesearch.searchable_types');
         $results = true;
         $search_content = $this->config->get('plugins.simplesearch.search_content');
 

--- a/simplesearch.yaml
+++ b/simplesearch.yaml
@@ -13,3 +13,7 @@ ignore_accented_characters: false
 order:
     by: date
     dir: desc
+searchable_types:
+    - title
+    - content
+    - taxonomy


### PR DESCRIPTION
I wanted to limit the search scope to titles only, and thought it would be great if this can be provided as a configuration setting. 