### PR TITLE
Let's tell screenreaders what this form is for

### DIFF
--- a/templates/partials/simplesearch_searchbox.html.twig
+++ b/templates/partials/simplesearch_searchbox.html.twig
@@ -1,10 +1,11 @@
 {% set min_chars = config.get('plugins.simplesearch.min_query_length', 3) %}
 <div class="search-wrapper">
-    <form name="search" data-simplesearch-form>
+    <form name="search" aria-label="Search form" data-simplesearch-form>
         <input
             name="searchfield"
             class="search-input"
             type="text"
+            aria-label="Search input"
             {% if min_chars > 0 %} min="{{- min_chars -}}" {% endif %}
             required
             placeholder="{{"PLUGIN_SIMPLESEARCH.SEARCH_PLACEHOLDER"|t}}"


### PR DESCRIPTION
Without a label, screenreaders don't know what this form is for.

Let's tell them, using an aria-label.