### PR TITLE
Default vs. custom simplesearch.md

### DIFF
--- a/simplesearch.php
+++ b/simplesearch.php
@@ -96,7 +96,7 @@ class SimplesearchPlugin extends Plugin
         }
 
         // If a page exists merge the configs
-        if ($page) {
+        if (isset($page)) {
             $this->config->set('plugins.simplesearch', $this->mergeConfig($page));
         }
 
@@ -108,6 +108,12 @@ class SimplesearchPlugin extends Plugin
         // performance check for route
         if (!($route && $route == $uri->path())) {
             return;
+        }
+
+        // set the template is not set in the page header (the page header setting takes precedence over the plugin config setting)
+        if (!isset($page->header()->template)) {
+            $template_override = $this->config->get('plugins.simplesearch.template', 'simplesearch_results');
+            $page->template($template_override);
         }
 
         // Explode query into multiple strings. Drop empty values
@@ -225,15 +231,17 @@ class SimplesearchPlugin extends Plugin
             );
         }
 
-        // if page doesn't have settings set, create a page
-        if (!isset($page->header()->simplesearch)) {
+        // Display simplesearch page if no page was found for the current route
+        $pages = $this->grav['pages'];
+        $page = $pages->dispatch($this->config->get('plugins.simplesearch.route', '/search'), true);
+        if (!isset($page)) {
             // create the search page
             $page = new Page;
             $page->init(new \SplFileInfo(__DIR__ . '/pages/simplesearch.md'));
 
-            // override the template is set in the config
+            // override the template is set in the plugin config (the plugin config setting takes precedence over the page header setting)
             $template_override = $this->config->get('plugins.simplesearch.template');
-            if ($template_override) {
+            if (isset($template_override)) {
                 $page->template($template_override);
             }
 


### PR DESCRIPTION
Made code modifications to create a custom page without having to include a simplesearch section in the header. If the custom page contains a template variable in the header, it takes precedence over the setting in the config file. When using the default page, the opposite behavior occurs, where the settings in the config file are preferred, which overrides the settings in the page header, assuming that the default page now contains the template variable directly from the plugin authors.

This fixes some of the issues described in https://github.com/getgrav/grav-plugin-simplesearch/issues/173 and https://github.com/getgrav/grav-plugin-simplesearch/issues/43 (maybe others too).

I will send other separate improvements in the next Pull request.