### PR TITLE
Added autofocus attribute to search input

### DIFF
--- a/templates/partials/simplesearch_searchbox.html.twig
+++ b/templates/partials/simplesearch_searchbox.html.twig
@@ -13,6 +13,7 @@
             data-search-invalid="{{ "PLUGIN_SIMPLESEARCH.SEARCH_FIELD_MINIMUM_CHARACTERS"|t(min_chars)|raw }}"
             data-search-separator="{{ config.system.param_sep }}"
             data-search-input="{{ base_url }}{{ config.plugins.simplesearch.route == '@self' ? '' : (config.plugins.simplesearch.route == '/' ? '' : config.plugins.simplesearch.route) }}/query"
+            autofocus
         />
         {% if config.plugins.simplesearch.display_button %}
             <button type="submit" class="search-submit">


### PR DESCRIPTION
In my opinion always adding autofocus, or adding a setting to disable it, would be an improvement for the website visitor.
This way the visitor can just start typing when the search page was opened.