### PR TITLE
Fold accented characters with intl Transliterator (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.3.2
+## 07/20/2026
+
+1. [](#bugfix)
+    * Accent-insensitive search now works regardless of the server's locale, so accented and unaccented spellings match each other in languages beyond Western European ([#207](https://github.com/getgrav/grav-plugin-simplesearch/issues/207)).
+
 # v2.3.1
 ## 05/01/2026
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,7 +1,7 @@
 name: SimpleSearch
 type: plugin
 slug: simplesearch
-version: 2.3.1
+version: 2.3.2
 description: "Don't be fooled, the **SimpleSearch** plugin provides a **fast** and highly **configurable** way to search your content."
 icon: search
 author:

--- a/simplesearch.php
+++ b/simplesearch.php
@@ -386,17 +386,34 @@ class SimplesearchPlugin extends Plugin
     private function matchText($haystack, $needle)
     {
         if ($this->config->get('plugins.simplesearch.ignore_accented_characters')) {
-            setlocale(LC_ALL, 'en_US');
-            try {
-                $result = mb_stripos(iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $haystack), iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $needle));
-            } catch (\Exception $e) {
-                $result = mb_stripos($haystack, $needle);
-            }
-            setlocale(LC_ALL, '');
-            return $result;
+            return mb_stripos(static::deaccent($haystack), static::deaccent($needle));
         }
 
         return mb_stripos($haystack, $needle);
+    }
+
+    /**
+     * Fold accented characters to their ASCII equivalents for accent-insensitive search.
+     *
+     * Uses the intl Transliterator, which is locale-independent (no setlocale global-state
+     * mutation) and covers non-Latin-1 scripts that the old iconv//TRANSLIT approach silently
+     * dropped. The Any-Latin; Latin-ASCII chain matches Grav core's symfony/string convention
+     * and correctly folds both the comma-below and cedilla forms of characters like ș/ț.
+     * Falls back to the raw text (plain mb_stripos matching) when ext-intl is unavailable.
+     *
+     * @param string $text
+     * @return string
+     */
+    private static function deaccent($text)
+    {
+        static $tl = false;
+        if ($tl === false) {
+            $tl = class_exists(\Transliterator::class)
+                ? \Transliterator::create('Any-Latin; Latin-ASCII')
+                : null;
+        }
+
+        return $tl ? $tl->transliterate($text) : $text;
     }
 
     /**


### PR DESCRIPTION
`ignore_accented_characters` called `setlocale(LC_ALL, 'en_US')` (no UTF-8 codeset) before `iconv //TRANSLIT`, so on glibc it silently failed to fold any character outside Latin-1 — accent-insensitive search quietly no-oped for Romanian, Polish, Hungarian, Czech, etc.

Replaced with the intl `Transliterator` (`Any-Latin; Latin-ASCII`), which is locale-independent, handles scripts beyond Latin-1, and matches how Grav core folds Latin-ASCII. Falls back to plain `mb_stripos` if ext-intl is absent.

Fixes #207